### PR TITLE
Check download type

### DIFF
--- a/downloader.go
+++ b/downloader.go
@@ -139,6 +139,10 @@ func GetDocker(version string, binDir string) {
 		log.Fatal(err)
 	}
 
+	if http.DetectContentType(body) != "application/octet-stream" {
+		log.Fatal("download not Content-Type application/octet-stream; check the version exists")
+	}
+
 	_err = ioutil.WriteFile(usr.HomeDir+"/.dkenv/docker-"+version, body, 0777)
 
 	SwitchVersion(version, binDir)


### PR DESCRIPTION
Uses http.DetectContentType() to bail out on invalid downloads.

@talpert @dselans @mikkergimenez @msneeden 

Merge after the #7 gofmt PR if this looks good.
