### PR TITLE
Fail on download of != application/octet-stream

### DIFF
--- a/lib/downloader.go
+++ b/lib/downloader.go
@@ -45,8 +45,9 @@ func (d *Dkenv) DownloadDocker(version string) error {
 		return err
 	}
 
-	if http.DetectContentType(body) != "application/octet-stream" {
-		log.Fatal("Download not Content-Type application/octet-stream; check the version exists")
+	contentType := http.DetectContentType(body)
+	if contentType != "application/octet-stream" {
+		return fmt.Errorf("Content-Type mismatch: %s detected", contentType)
 	}
 
 	if err := ioutil.WriteFile(d.DkenvDir+"/docker-"+version, body, 0755); err != nil {

--- a/lib/downloader.go
+++ b/lib/downloader.go
@@ -45,6 +45,10 @@ func (d *Dkenv) DownloadDocker(version string) error {
 		return err
 	}
 
+	if http.DetectContentType(body) != "application/octet-stream" {
+		log.Fatal("Download not Content-Type application/octet-stream; check the version exists")
+	}
+
 	if err := ioutil.WriteFile(d.DkenvDir+"/docker-"+version, body, 0755); err != nil {
 		return fmt.Errorf("Error(s) writing docker binary: %v", err)
 	}


### PR DESCRIPTION
dkenv now checks for a 200 on download, but this is a belt and
suspenders approach to not writing out something that is not a docker
binary.

CC @dselans @mikkergimenez 
